### PR TITLE
Ignore backup files and XML generated by ant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ gradle/.launch/
 ehthumbs.db
 Thumbs.db
 
+# backup files
+*~
+
+# directory for XML generated after running junit tests through ant
+junit/


### PR DESCRIPTION
Files ending in ~ are backup files generated by [gedit](https://en.wikipedia.org/wiki/Gedit) and shouldn't be put in a repository. The junit/ directory is for XML automatically generated by running [JUnit](https://en.wikipedia.org/wiki/JUnit) tests through [Apache Ant](https://en.wikipedia.org/wiki/Apache_Ant) and also has no place in a repository.
