### PR TITLE
Ignore module jar files for toast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tmp/
 run/
 .gradle/
 gradle/.launch/
+modules/*.jar
 
 # OS Files
 .DS_Store


### PR DESCRIPTION
You don't want to commit these, but I like to put a text or markdown file in the folder to keep track of module versions and provide links to get them.
